### PR TITLE
create error merge rules

### DIFF
--- a/app/assets/stylesheets/errbit.css.erb
+++ b/app/assets/stylesheets/errbit.css.erb
@@ -996,3 +996,24 @@ table.users td img.gravatar {
   vertical-align: middle;
   margin-left: 3px;
 }
+#occurrences {
+    width: 100%;
+    overflow-x: auto;
+}
+
+#occurrences table {
+    width: 100%;
+    table-layout: auto;
+    border-collapse: collapse;
+}
+
+#occurrences th,
+#occurrences td {
+    white-space: wrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    max-width: 150px;
+}
+.rule-text-area {
+    width: 96%;
+}

--- a/app/controllers/problems_controller.rb
+++ b/app/controllers/problems_controller.rb
@@ -58,7 +58,13 @@ class ProblemsController < ApplicationController
         @notices.first
       end
     @notice  = notice ? NoticeDecorator.new(notice) : nil
+    @all_notices = problem.object.notices.reverse_ordered.page(params[:page]).per(5)
     @comment = Comment.new
+
+    respond_to do |format|
+      format.html
+      format.js
+    end
   end
 
   def show_by_id

--- a/app/controllers/rules_controller.rb
+++ b/app/controllers/rules_controller.rb
@@ -1,0 +1,53 @@
+class RulesController < ApplicationController
+
+  expose(:apps) do
+    App.all.to_a.sort.map { |app| AppDecorator.new(app) }
+  end
+
+  expose(:rule)
+
+  expose(:rules) do
+    Rule.all.to_a.sort.map { |rule| RuleDecorator.new(rule) }
+  end
+
+  expose(:rule_decorate) do
+    RuleDecorator.new(rule)
+  end
+
+  def index; end
+
+  def show; end
+
+  def new; end
+
+  def create
+    # @rule = Rule.new(rule_params)
+    if rule.save
+      flash[:success] = "#{I18n.t('controllers.rules.flash.rule_creation_success')}."
+      redirect_to rules_path
+    else
+      render :new
+    end
+  end
+
+  def edit; end
+
+  def update
+    if rule.update(rule_params)
+      redirect_to rules_path, notice: "#{I18n.t('controllers.rules.flash.rule_update_success')}."
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    rule.destroy
+    redirect_to rules_path, notice: "#{I18n.t('controllers.rules.flash.rule_delete_success')}."
+  end
+
+private
+
+  def rule_params
+    params.require(:rule).permit(:name, :condition, :app_id)
+  end
+end

--- a/app/decorators/rule_decorator.rb
+++ b/app/decorators/rule_decorator.rb
@@ -1,0 +1,12 @@
+class RuleDecorator < Draper::Decorator
+  delegate_all
+
+  # Define presentation-specific methods here. Helpers are accessed through
+  # `helpers` (aka `h`). You can override attributes, for example:
+  #
+  #   def created_at
+  #     helpers.content_tag :span, class: 'time' do
+  #       object.created_at.strftime("%a %m/%d/%y")
+  #     end
+  #   end
+end

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -28,6 +28,7 @@ class App
   embeds_one :notice_fingerprinter
 
   has_many :problems, inverse_of: :app, dependent: :destroy
+  has_many :rules, inverse_of: :app, dependent: :destroy
 
   before_validation :generate_api_key, on: :create
   before_save :normalize_github_repo

--- a/app/models/error_report.rb
+++ b/app/models/error_report.rb
@@ -58,6 +58,7 @@ class ErrorReport
 
     retrieve_problem_was_resolved
     cache_attributes_on_problem
+    merge_problems
     email_notification
     services_notification
     @notice
@@ -79,6 +80,17 @@ class ErrorReport
 
   def retrieve_problem_was_resolved
     @problem_was_resolved = Problem.where('_id' => @error.problem_id, resolved: true).exists?
+  end
+
+  def merge_problems
+    merge_rules = app.rules
+    merge_rules.each do |rule|
+      problems = find_problems_matching_rule(rule)
+      next if problems.empty?
+
+      ProblemMerge.new(problems).merge
+      break
+    end
   end
 
   # Update problem cache with information about this notice
@@ -142,5 +154,13 @@ class ErrorReport
 
   def fingerprint
     app.notice_fingerprinter.generate(api_key, notice, backtrace)
+  end
+
+  def find_problems_matching_rule(rule)
+    primary_problem = Problem.where(id: @error.problem_id, message: /#{Regexp.escape(rule.condition)}/i).first
+    return [] unless primary_problem
+
+    other_problems = Problem.where(:id.ne => @error.problem_id, message: /#{Regexp.escape(rule.condition)}/i)
+    other_problems.present? ? [primary_problem, *other_problems] : []
   end
 end

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -1,0 +1,12 @@
+class Rule
+  include Mongoid::Document
+  include Mongoid::Timestamps
+
+  field :name, type: String
+  field :condition, type: String
+
+  belongs_to :app
+
+  validates :name, presence: true
+  validates :condition, presence: true
+end

--- a/app/views/problems/_notices_table.html.haml
+++ b/app/views/problems/_notices_table.html.haml
@@ -1,0 +1,20 @@
+#occurrences
+  %table.rules
+    %thead
+      %tr
+        %th Timestamp
+        %th Error Class
+        %th User Agent
+        %th request.url
+        %th Message
+    %tbody
+      - notices.each do |notice|
+        %tr
+          %td= notice.created_at.strftime('%B %d, %Y %H:%M:%S')
+          %td= notice.error_class
+          %td= user_agent_graph(notice.problem)
+          %td= notice.request['url']
+          %td= link_to notice.message, app_problem_path(notice.problem.app, notice.problem), class: 'nowrap', title: notice.problem.message
+
+.pagination
+  = paginate notices, remote: true

--- a/app/views/problems/show.html.haml
+++ b/app/views/problems/show.html.haml
@@ -67,6 +67,7 @@
     %li= link_to t('.environment'), '#environment', :rel => 'environment', :class => 'button'
     %li= link_to t('.parameters'), '#params', :rel => 'params', :class => 'button'
     %li= link_to t('.session'), '#session', :rel => 'session', :class => 'button'
+    %li= link_to t('.occurrences'), '#occurrences', :rel => 'occurrences', :class => 'button'
 
 - if @notice
   #summary
@@ -93,3 +94,6 @@
   #session
     %h3 Session
     = render 'notices/session', :notice => @notice
+
+#occurrences
+  = render partial: 'notices_table', locals: { notices: @all_notices }

--- a/app/views/problems/show.js.erb
+++ b/app/views/problems/show.js.erb
@@ -1,0 +1,2 @@
+$('#occurrences').html("<%= j render partial: 'notices_table', locals: { notices: @all_notices } %>");
+$('.pagination').html("<%= j paginate @all_notices, remote: true %>");

--- a/app/views/rules/_form.html.haml
+++ b/app/views/rules/_form.html.haml
@@ -1,0 +1,18 @@
+= form_for rule_decorate do |f|
+  %div
+    = f.label :name
+    = f.text_field :name, required: true
+
+  %div
+    = f.label :condition
+    = f.text_area :condition, required: true, class: 'rule-text-area'
+
+    %small Note: Error are merged using Error.message.include?(condition) Case-insensitive.
+
+
+  %div
+    = f.label :app
+    = f.collection_select :app_id, apps, :id, :name, include_blank: true, required: true
+
+  %div
+    = f.submit "Save"

--- a/app/views/rules/edit.html.haml
+++ b/app/views/rules/edit.html.haml
@@ -1,0 +1,3 @@
+%h1= action_name.capitalize + " Rule"
+
+= render 'form', rule: @rule

--- a/app/views/rules/index.html.haml
+++ b/app/views/rules/index.html.haml
@@ -1,0 +1,30 @@
+
+- content_for :title, t('.rules')
+- content_for :action_bar do
+  - if current_user.admin?
+    %span
+      = link_to(new_rule_path) do
+        %i.fa.fa-plus-circle
+        = t('.add_new_rule')
+
+
+
+%table
+  %thead
+    %tr
+      %th Name
+      %th Condition
+      %th App
+      %th Actions
+  %tbody
+    - rules.each do |rule|
+      %tr
+        %td= rule.name
+        %td= rule.condition
+        %td= rule.app.name
+        %td
+          = link_to 'Show', rule_path(rule)
+          = link_to 'Edit', edit_rule_path(rule)
+          = link_to 'Delete', rule_path(rule), method: :delete, data: { confirm: 'Are you sure?' }
+
+

--- a/app/views/rules/new.html.haml
+++ b/app/views/rules/new.html.haml
@@ -1,0 +1,3 @@
+%h1= action_name.capitalize + " Rule"
+
+= render 'form'

--- a/app/views/rules/show.html.haml
+++ b/app/views/rules/show.html.haml
@@ -1,0 +1,13 @@
+- content_for :title, rule.name
+
+- content_for :action_bar do
+  = link_to t('.back'), rules_path, :class => 'button'
+  = link_to t('.edit'), edit_rule_path(rule), :class => 'button'
+
+%table.single_user
+  %tr
+    %th= t('.condition')
+    %td= rule.condition
+  %tr
+    %th= t('.app')
+    %td= rule.app.name

--- a/app/views/shared/_navigation.html.haml
+++ b/app/views/shared/_navigation.html.haml
@@ -17,4 +17,8 @@
         = link_to site_config_index_path do
           %i.fa.fa-wrench
           = t('.config')
+      %li{:class => active_if_here(:rules)}
+        = link_to rules_path do
+          %i.fa.fa-file
+          = t('.rules')
   %div.clear

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -91,6 +91,11 @@ en:
         need_two_errors_merge: "You must select at least two errors to merge"
         merge_several:
           success: "%{nb} errors have been merged."
+    rules:
+      flash:
+        rule_creation_success: "Rule was successfully created"
+        rule_update_success: "Rule was successfully updated"
+        rule_delete_success: "Rule was successfully deleted"
 
   devise:
     registrations:
@@ -290,6 +295,16 @@ en:
       app_version: App Version
       framework: Framework
       relative_directory: Rel. Directory
+  rules:
+    index:
+      add_new_rule: Add a New Rule
+      add_rule: Add Rule
+      cancel: Cancel
+    show:
+      edit: Edit
+      back: Back
+      condition: Condition
+      app: App
   notice_fingerprinter:
     title: Notice Fingerprinter
     text: The notice fingerprinter governs how error notifications are grouped. Each item counts toward an error's uniqueness if enabled.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,6 +58,8 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
     end
   end
 
+  resources :rules
+
   get 'problems/:id' => 'problems#show_by_id'
 
   get 'health/readiness' => 'health#readiness'


### PR DESCRIPTION
- Defines a `rule` to merge errors based on `string inclusion`.
- Allows users to create rules specific to apps.
- Enables merging of errors after rules are created for an app.
- Adds an` Occurrences` tab to the problem show page.
- Displays all merged errors in this tab with pagination.
- Provides users the ability to click and view merged problems.