### PR TITLE
fix previous and next link full page reload

### DIFF
--- a/app/views/kaminari/_next_page.html.haml
+++ b/app/views/kaminari/_next_page.html.haml
@@ -6,4 +6,4 @@
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
 %span.next
-  = link_to_unless current_page.last?, raw('Next &raquo;'), url, :rel => 'next'
+  = link_to_unless current_page.last?, raw('Next &raquo;'), url, {:remote => remote, :rel => 'next'}

--- a/app/views/kaminari/_prev_page.html.haml
+++ b/app/views/kaminari/_prev_page.html.haml
@@ -6,4 +6,4 @@
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
 %span.prev
-  = link_to_unless current_page.first?, raw('&laquo; Previous'), url, :rel => 'prev'
+  = link_to_unless current_page.first?, raw('&laquo; Previous'), url, {:remote => remote, :rel => 'prev'}


### PR DESCRIPTION
**Issue:**

Clicking the `Previous` or `Next` button in the **Occurrences** tab on the `problem#show` page causes the entire page to reload.

**Fix:**

Resolved the issue so that clicking `Previous` or `Next` in the **Occurrences** tab now updates the content dynamically without reloading the entire page.

https://github.com/user-attachments/assets/f72ce6c5-4cc0-47f3-9f63-5100be0b7a58

