### PR TITLE
add param validation for message and backtrace

### DIFF
--- a/app/views/problems/_notices_table.html.haml
+++ b/app/views/problems/_notices_table.html.haml
@@ -12,7 +12,7 @@
           %td= notice.created_at.strftime('%B %d, %Y %H:%M:%S')
           %td= notice.error_class
           %td= notice.where
-          %td= link_to notice.message, app_problem_notice(notice.problem.app, notice.problem, notice), class: 'nowrap', title: notice.problem.message
+          %td= link_to notice.message, app_problem_notices_path(notice.problem.app, notice.problem, notice), class: 'nowrap', title: notice.problem.message
 
 .pagination
   = paginate notices, remote: true


### PR DESCRIPTION
- Added param validation for `message` and `backtrace` field.
- App will throw 400 Bad Request Error.
- This will fix this error [NoMethodError: undefined method `mb_chars' for nil:NilClass truncated_m = m.mb_chars.compose.limit(MESSAGE_LENGTH_LIMIT).to_s](https://errbit.inventory.horse/apps/673391882490d90009b17ed0/problems/67a3af86eb5790000be5b7fd)